### PR TITLE
Make init return a guard which will shutdown the tracing provider on drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,8 @@ and shut down the exporter like this:
 ```rust
 #[tokio::main]
 async fn main() {
-    tracing_axiom::init(); // or try_init() to handle errors
+    let _guard = tracing_axiom::init(); // or try_init() to handle errors
     say_hello();
-    tracing_axiom::shutdown();
 }
 
 #[tracing::instrument]
@@ -50,7 +49,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
   let trace_config = trace::Config::default()
     .with_max_events_per_span(42);
 
-  tracing_axiom::builder()
+  let _guard = tracing_axiom::builder()
     .with_token("xaat-123456789")
     .with_url("https://my-axiom.example.org")
     .with_service_name("my-service")

--- a/examples/fmt/src/main.rs
+++ b/examples/fmt/src/main.rs
@@ -3,7 +3,7 @@ use tracing_subscriber::prelude::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let axiom_layer = tracing_axiom::builder().with_service_name("fmt").layer()?;
+    let (axiom_layer, _guard) = tracing_axiom::builder().with_service_name("fmt").layer()?;
     let fmt_layer = tracing_subscriber::fmt::layer().pretty();
     tracing_subscriber::registry()
         .with(fmt_layer)
@@ -12,7 +12,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     say_hello();
 
-    tracing_axiom::shutdown();
     Ok(())
 }
 

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -2,9 +2,8 @@ use tracing::{info, instrument};
 
 #[tokio::main]
 async fn main() {
-    tracing_axiom::init();
+    let _guard = tracing_axiom::init();
     say_hello();
-    tracing_axiom::shutdown();
 }
 
 #[instrument]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -96,8 +96,7 @@ impl Builder {
         Ok((layer, Guard {}))
     }
 
-    /// Create a tracer which sends traces to Axiom.
-    pub fn tracer(self) -> Result<Tracer, Error> {
+    fn tracer(self) -> Result<Tracer, Error> {
         let token = self
             .token
             .ok_or(Error::MissingToken)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,11 +74,3 @@ pub fn try_init() -> Result<Guard, Error> {
 pub fn builder() -> Builder {
     Builder::new()
 }
-
-/// Shutdown the tracer prodiver, flushing all spans.
-/// Calling this before exit is only necessary for advanced configurations,
-/// [`init`] and [`try_init`] as well as respective methods on the [`Builder`]
-/// will return a [`Guard`] which will do this for you.
-pub fn shutdown() {
-    opentelemetry::global::shutdown_tracer_provider();
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,8 @@
 //! ```
 //! #[tokio::main]
 //! async fn main() {
-//!     tracing_axiom::init();
+//!     let _guard = tracing_axiom::init();
 //!     say_hello();
-//!     tracing_axiom::shutdown();
 //! }
 //!
 //! #[tracing::instrument]
@@ -30,7 +29,7 @@ use url::Url;
 mod builder;
 mod error;
 
-pub use builder::Builder;
+pub use builder::{Builder, Guard};
 pub use error::Error;
 
 #[cfg(doctest)]
@@ -52,7 +51,7 @@ lazy_static! {
 /// Panics if the initialization was unsuccessful, likely because a global
 /// subscriber was already installed or `AXIOM_TOKEN` is not set or invalid.
 /// If you want to handle the error instead, use [`try_init`].
-pub fn init() {
+pub fn init() -> Guard {
     Builder::new().init()
 }
 
@@ -67,7 +66,7 @@ pub fn init() {
 /// Returns an error if the initialization was unsuccessful, likely because a
 /// global subscriber was already installed or `AXIOM_TOKEN` is not set or
 /// invalid.
-pub fn try_init() -> Result<(), Error> {
+pub fn try_init() -> Result<Guard, Error> {
     Builder::new().try_init()
 }
 
@@ -76,7 +75,10 @@ pub fn builder() -> Builder {
     Builder::new()
 }
 
-/// Shutdown the tracer prodiver, flushing all spans. Run this before exit.
+/// Shutdown the tracer prodiver, flushing all spans.
+/// Calling this before exit is only necessary for advanced configurations,
+/// [`init`] and [`try_init`] as well as respective methods on the [`Builder`]
+/// will return a [`Guard`] which will do this for you.
 pub fn shutdown() {
     opentelemetry::global::shutdown_tracer_provider();
 }


### PR DESCRIPTION
This is an experiment, I'm not sure if it's worth it.

Instead of requiring people to call `tracing_axiom`, all `init` and `try_init` methods/functions now return a `Guard` that will shutdown on drop.


This makes the setup actual one-line:
```rust
let _guard = tracing_axiom::init();
```

If you forget to assign it to a var, you'll get a compile-time warning that looks like this:

![Screenshot 2022-08-26 at 15 02 53](https://user-images.githubusercontent.com/1725839/186909551-807ca5b9-3f32-4eb1-9be4-148b2b74d516.png)

This also makes the `tracer()` method internal, we can always expose it if there's a demand.