### PR TITLE
Update README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,6 @@
 
 * [simple](./simple) - Uses defaults provided by Axiom and is a one line setup.
 * [fmt](./fmt) - Uses layers with out of the box local formatting and Axiom remote endpoint.
-* [sdk](./sdk) - Shows how tracing and the Axiom SDK can be used together.
 * [layers](./layers) - The kitchen sink. If you have a rich tracing setup, just plug tracing-axiom into your existing setup.
 * [noenv]('./noenv) - Example that does not use environment variables for tracing setup.
 


### PR DESCRIPTION
Remove reference to `sdk` example which exists no more! We missed this in the review!