### PR TITLE
feat(builder): Add tokio feature, which can be omitted

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,23 +15,37 @@ include = ["src/**/*.rs", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 resolver = "2"
 
 [dependencies]
-opentelemetry = { version =  "0.20", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.13", features = ["prost", "tokio", "http-proto", "reqwest-client" ] }
+opentelemetry = "0.20"
+opentelemetry-otlp = { version = "0.13", features = [
+  "prost",
+  "http-proto",
+  "reqwest-client",
+] }
 tracing-core = { version = "0.1", default-features = false, features = ["std"] }
 tracing-opentelemetry = { version = "0.21", default-features = false }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["smallvec", "std", "registry", "fmt", "json" ] }
-reqwest = { version = "0.11", default-features = false }
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+  "smallvec",
+  "std",
+  "registry",
+  "fmt",
+  "json",
+] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking"] }
 thiserror = "1"
 opentelemetry-semantic-conventions = "0.12"
 url = "2.4.1"
 
 [dev-dependencies]
 tokio = "1"
-tracing = { version = "0.1", features = [ "log" ] }
-opentelemetry = { version =  "0.20", features = ["rt-tokio"] }
+tracing = { version = "0.1", features = ["log"] }
+opentelemetry = { version = "0.20", features = ["rt-tokio"] }
 
 [features]
-default = ["default-tls"]
+default = ["default-tls", "tokio"]
 default-tls = ["reqwest/default-tls"]
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
+tokio = [
+  "opentelemetry/rt-tokio",
+  "opentelemetry-otlp/tokio",
+]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ that can be enabled or disabled:
   over HTTPS.
 - **native-tls**: Enables TLS functionality provided by `native-tls`.
 - **rustls-tls**: Enables TLS functionality provided by `rustls`.
+- **tokio** _(enabled by default)_: Uses a more efficient batch processor.
 
 ## FAQ & Troubleshooting
 ### How do I log traces to the console in addition to Axiom?

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -314,16 +314,16 @@ impl Builder {
 
         let tracer = opentelemetry_otlp::new_pipeline()
             .tracing()
-            .with_exporter(
-                opentelemetry_otlp::new_exporter()
+            .with_exporter({
+                let exporter = opentelemetry_otlp::new_exporter()
                     .http()
-                    .with_http_client(reqwest::Client::new())
                     .with_endpoint(url)
                     .with_headers(headers)
-                    .with_timeout(Duration::from_secs(3)),
-            )
-            .with_trace_config(trace_config)
-            .install_batch(opentelemetry::runtime::Tokio)?;
+                    .with_timeout(Duration::from_secs(3));
+                return exporter.with_http_client(reqwest::blocking::Client::new());
+            })
+            .with_trace_config(trace_config);
+        let tracer = tracer.install_simple()?;
         Ok(tracer)
     }
 }


### PR DESCRIPTION
This enabled an application, that doesn't use a Tokio runtime, to use axiom-tracing.