### PR TITLE
fix: append service.name to prevent it being overidden

### DIFF
--- a/examples/layers/main.rs
+++ b/examples/layers/main.rs
@@ -22,7 +22,10 @@ fn setup_tracing(otel_is_configured: bool, tags: &[(&str, &str)]) -> Result<(), 
             .with_target(false);
 
         // Setup an Axiom OpenTelemetry compatible tracing layer
-        let axiom_layer = tracing_axiom::builder().with_tags(tags).layer()?;
+        let axiom_layer = tracing_axiom::builder()
+            .with_service_name("layers")
+            .with_tags(tags)
+            .layer()?;
 
         // Setup our multi-layered tracing subscriber
         Registry::default()

--- a/examples/noenv/main.rs
+++ b/examples/noenv/main.rs
@@ -9,6 +9,7 @@ fn say_hi(id: Uuid, name: impl Into<String> + std::fmt::Debug) {
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_axiom::builder()
+        .with_service_name("noenv")
         .with_tags(&[("aws_region", "us-east-1")]) // Set otel tags
         .with_dataset("tracing-axiom-examples") // Set dataset
         .with_token("xaat-some-valid-token") // Set API token

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -259,6 +259,7 @@ impl Builder {
         ]);
 
         if let Some(service_name) = self.service_name {
+            // TODO: Is there a way to get the name of the bin crate using this?
             tags.push(KeyValue::new(SERVICE_NAME, service_name));
         }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -251,14 +251,6 @@ impl Builder {
             format!("tracing-axiom/{}", env!("CARGO_PKG_VERSION")),
         );
 
-        let mut trace_config = self.trace_config.unwrap_or_default();
-        if let Some(service_name) = self.service_name {
-            trace_config = trace_config.with_resource(Resource::new(vec![KeyValue::new(
-                SERVICE_NAME,
-                service_name, // TODO: Is there a way to get the name of the bin crate using this?
-            )]));
-        }
-
         let mut tags = self.tags.clone();
         tags.extend(vec![
             KeyValue::new(TELEMETRY_SDK_NAME, env!("CARGO_PKG_NAME").to_string()),
@@ -266,7 +258,14 @@ impl Builder {
             KeyValue::new(TELEMETRY_SDK_LANGUAGE, "rust".to_string()),
         ]);
 
-        trace_config = trace_config.with_resource(Resource::new(tags));
+        if let Some(service_name) = self.service_name {
+            tags.push(KeyValue::new(SERVICE_NAME, service_name));
+        }
+
+        let trace_config = self
+            .trace_config
+            .unwrap_or_default()
+            .with_resource(Resource::new(tags));
 
         let tracer = opentelemetry_otlp::new_pipeline()
             .tracing()


### PR DESCRIPTION
It looks like the `with_resource` function overrides previous resources if called more than once leading to the `service.name` to be deleted :(.

Here's a small video of the current behaviour and the proposed fix. [here's the repro](https://github.com/FinnDore/service-name-thing)


https://github.com/axiomhq/tracing-axiom/assets/34718806/b116b1b3-5415-4651-8820-2ab2733d8645

