### PR TITLE
docs: fix Axiom settings and API URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ tracing-axiom = "0.7"
 
 Create a dataset in Axiom and export the name as `AXIOM_DATASET`.
 Then create an API token with ingest permission into that dataset in
-[the Axiom settings](https://cloud.axiom.co/settings/profile) and export it as
+[the Axiom settings](https://app.axiom.co/settings/profile) and export it as
 `AXIOM_TOKEN`.
 
 Now you can set up tracing like this:

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -23,7 +23,7 @@ const CLOUD_URL: &str = "https://api.axiom.co";
 /// Builder for creating a tracing tracer, a layer or a subscriber that sends traces to
 /// Axiom via the `OpenTelemetry` protocol. The API token is read from the `AXIOM_TOKEN`
 /// environment variable. The dataset name is read from the `AXIOM_DATASET` environment
-/// variable. The URL defaults to Axiom Cloud whose URL is `https://cloud.axiom.co` but
+/// variable. The URL defaults to Axiom API whose URL is `https://api.axiom.co` but
 /// can be overridden by setting the `AXIOM_URL` environment variable for testing purposes
 ///
 #[derive(Debug, Default)]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -138,18 +138,18 @@ impl Builder {
             if let Some(t) = get_env("AXIOM_TOKEN")? {
                 self = self.with_token(t)?;
             }
-        };
+        }
 
         if self.dataset_name.is_none() {
             if let Some(d) = get_env("AXIOM_DATASET")? {
                 self = self.with_dataset(d)?;
             }
-        };
+        }
         if self.url.is_none() {
             if let Some(u) = get_env("AXIOM_URL")? {
                 self = self.with_url(&u)?;
             }
-        };
+        }
 
         Ok(self)
     }


### PR DESCRIPTION
Updates the Axiom settings profile link to use `app.axiom.co` and corrects the builder docstring so it matches `CLOUD_URL` (`https://api.axiom.co`) instead of the outdated `cloud.axiom.co` wording.

Made with [Cursor](https://cursor.com)